### PR TITLE
2dGridSearch delete/free mismatch

### DIFF
--- a/src/utils/2Dgridsearch.cpp
+++ b/src/utils/2Dgridsearch.cpp
@@ -809,7 +809,8 @@ bool SBPL2DGridSearch::search_withslidingbuckets(unsigned char** Grid2D, unsigne
     else
         largestcomputedoptf_ = INFINITECOST;
 
-    delete[] pbClosed;
+    //delete[] pbClosed;
+    free(pbClosed);
 
     SBPL_PRINTF( "# of expands during 2dgridsearch=%d time=%d msecs 2Dsolcost_inmm=%d "
                 "largestoptfval=%d (start=%d %d goal=%d %d)\n",


### PR DESCRIPTION
2dgridsearch.cpp: Replaced delete with free  in SBPL2DGridSearch::search_withslidingbuckets method
