### PR TITLE
Adds a method to request the used actions in EnvironmentNAVXYTHETALAT.

### DIFF
--- a/src/include/sbpl/discrete_space_information/environment_nav2D.h
+++ b/src/include/sbpl/discrete_space_information/environment_nav2D.h
@@ -45,6 +45,11 @@ class MDPConfig;
 //configuration parameters
 typedef struct ENV_NAV2D_CONFIG
 {
+    ENV_NAV2D_CONFIG() 
+    {
+        Grid2D = NULL;
+    }
+
     int EnvWidth_c;
     int EnvHeight_c;
     int StartX_c;
@@ -75,8 +80,13 @@ typedef struct ENVHASHENTRY
 } EnvNAV2DHashEntry_t;
 
 //variables that dynamically change (e.g., array of states, ...)
-typedef struct
+typedef struct ENVNAV2D
 {
+    ENVNAV2D() 
+    {
+        Coord2StateIDHashTable = NULL;
+    }
+
     int startstateid;
     int goalstateid;
 

--- a/src/include/sbpl/discrete_space_information/environment_navxythetalat.h
+++ b/src/include/sbpl/discrete_space_information/environment_navxythetalat.h
@@ -516,6 +516,12 @@ public:
      * \brief returns stateID for a state with coords x,y,theta
      */
     virtual int GetStateFromCoord(int x, int y, int theta);
+    
+    /**
+     * \brief returns the actions / motion primitives of the passed path.
+     */
+    virtual void GetActionsFromStateIDPath(std::vector<int>* stateIDPath, 
+                                           std::vector<EnvNAVXYTHETALATAction_t>* action_list);
 
     /** \brief converts a path given by stateIDs into a sequence of
      *         coordinates. Note that since motion primitives are short actions


### PR DESCRIPTION
Allows to get a list of primitives which have been used to build the path.
This can be used to create a primitive-dependent trajectory.
The method is based on ConvertStateIDPathintoXYThetaPath().

In addition two constructors are added to avoid wild pointers.