### PR TITLE
Optional memory saving features related to SBPL2DGridSearch. 

### DIFF
--- a/src/discrete_space_information/environment_navxythetalat.cpp
+++ b/src/discrete_space_information/environment_navxythetalat.cpp
@@ -65,6 +65,8 @@ EnvironmentNAVXYTHETALATTICE::EnvironmentNAVXYTHETALATTICE()
     bNeedtoRecomputeStartHeuristics = true;
     bNeedtoRecomputeGoalHeuristics = true;
     iteration = 0;
+    bucketsize = 0; // fixed bucket size
+    blocksize = 1;
 
     EnvNAVXYTHETALAT.bInitialized = false;
 
@@ -1494,9 +1496,9 @@ void EnvironmentNAVXYTHETALATTICE::ComputeHeuristicValues()
 
     //allocated 2D grid searches
     grid2Dsearchfromstart = new SBPL2DGridSearch(EnvNAVXYTHETALATCfg.EnvWidth_c, EnvNAVXYTHETALATCfg.EnvHeight_c,
-                                                 (float)EnvNAVXYTHETALATCfg.cellsize_m);
+                                                 (float)EnvNAVXYTHETALATCfg.cellsize_m, blocksize, bucketsize);
     grid2Dsearchfromgoal = new SBPL2DGridSearch(EnvNAVXYTHETALATCfg.EnvWidth_c, EnvNAVXYTHETALATCfg.EnvHeight_c,
-                                                (float)EnvNAVXYTHETALATCfg.cellsize_m);
+                                                (float)EnvNAVXYTHETALATCfg.cellsize_m, blocksize, bucketsize);
 
     //set OPEN type to sliding buckets
     grid2Dsearchfromstart->setOPENdatastructure(SBPL_2DGRIDSEARCH_OPENTYPE_SLIDINGBUCKETS);
@@ -1766,6 +1768,16 @@ void EnvironmentNAVXYTHETALATTICE::PrintEnv_Config(FILE* fOut)
 
     SBPL_ERROR("ERROR in EnvNAVXYTHETALAT... function: PrintEnv_Config is undefined\n");
     throw new SBPL_Exception();
+}
+
+void EnvironmentNAVXYTHETALATTICE::Set2DBlockSize(int BlockSize)
+{
+    blocksize = BlockSize;
+}
+
+void EnvironmentNAVXYTHETALATTICE::Set2DBucketSize(int BucketSize)
+{
+    bucketsize = BucketSize;
 }
 
 void EnvironmentNAVXYTHETALATTICE::PrintTimeStat(FILE* fOut)

--- a/src/include/sbpl/discrete_space_information/environment_navxythetalat.h
+++ b/src/include/sbpl/discrete_space_information/environment_navxythetalat.h
@@ -35,6 +35,10 @@
 #include <sbpl/discrete_space_information/environment.h>
 #include <sbpl/utils/utils.h>
 
+// Define to test against in client code. Signals that Set2DBlockSize and
+// Set2DBucketSize are available in EnvironmentNAVXYTHETALATTICE
+#define SBPL_CUSTOM_2D_OPTIONS 1
+
 //eight-connected grid
 #define NAVXYTHETALAT_DXYWIDTH 8
 #define ENVNAVXYTHETALAT_DEFAULTOBSTHRESH 254	//see explanation of the value below
@@ -264,6 +268,20 @@ public:
     virtual void PrintEnv_Config(FILE* fOut);
 
     /**
+     * \brief set the block size for the 2D heuristic. A block size of 1 is the default and will result in
+     *        a single cell in the 2D heuristic search corresponding to 1 cell from the source map.
+     *        A block size of 2 will result in a single cell in the 2D heuristic search corresponding to
+     *        a 2x2 set of blocks from the source map with a cost of the max of the 2x2 source cells.
+     */
+    virtual void Set2DBlockSize(int BlockSize);
+
+    /**
+     * @brief Set2DBucketSize Set the initial size of the CSlidingBuckets used for the fringe priority list
+     * @param BucketSize
+     */
+    virtual void Set2DBucketSize(int BucketSize);
+
+    /**
      * \brief initialize environment. Gridworld is defined as matrix A of size width by height.
      *        So, internally, it is accessed as A[x][y] with x ranging from 0 to width-1 and and y from 0 to height-1
      *        Each element in A[x][y] is unsigned char. A[x][y] = 0 corresponds to
@@ -420,6 +438,8 @@ protected:
     std::vector<sbpl_xy_theta_cell_t> affectedsuccstatesV; //arrays of states whose outgoing actions cross cell 0,0
     std::vector<sbpl_xy_theta_cell_t> affectedpredstatesV; //arrays of states whose incoming actions cross cell 0,0
     int iteration;
+    int blocksize; // 2D block size
+    int bucketsize; // 2D bucket size
 
     //2D search for heuristic computations
     bool bNeedtoRecomputeStartHeuristics; //set whenever grid2Dsearchfromstart needs to be re-executed

--- a/src/include/sbpl/utils/2Dgridsearch.h
+++ b/src/include/sbpl/utils/2Dgridsearch.h
@@ -91,7 +91,15 @@ public:
 class SBPL2DGridSearch
 {
 public:
-    SBPL2DGridSearch(int width_x, int height_y, float cellsize_m);
+    /**
+     * @brief SBPL2DGridSearch Create a search space for 2D grids
+     * @param width_x grid width
+     * @param height_y grid height
+     * @param cellsize_m resolution
+     * @param downsample edge length of block in main grid that corresponds to a single cell in this grid
+     * @param initial_dynamic_bucket_size Initial dynamic bucket size, set to 0 for fixed size
+     */
+    SBPL2DGridSearch(int width_x, int height_y, float cellsize_m, int downsample=1, int initial_dynamic_bucket_size=32);
     ~SBPL2DGridSearch()
     {
         destroy();
@@ -132,6 +140,8 @@ public:
      */
     inline int getlowerboundoncostfromstart_inmm(int x, int y)
     {
+        x /= downsample_; // local x
+        y /= downsample_; // local y
         if (term_condition_usedlast == SBPL_2DGRIDSEARCH_TERM_CONDITION_OPTPATHFOUND) {
             //heuristic search
             int h = SBPL_2DGRIDSEARCH_HEUR2D(x,y);
@@ -167,6 +177,9 @@ private:
     inline void initializeSearchState2D(SBPL_2DGridSearchState* state2D);
     bool createSearchStates2D(void);
 
+    /// Pointer to getCost function appropriate for resample size
+    unsigned char (*getCost)(unsigned char**, int, int, int);
+
     bool search_withheap(unsigned char** Grid2D, unsigned char obsthresh, int startx_c, int starty_c, int goalx_c,
                          int goaly_c, SBPL_2DGRIDSEARCH_TERM_CONDITION termination_condition);
     bool search_exp(unsigned char** Grid2D, unsigned char obsthresh, int startx_c, int starty_c, int goalx_c,
@@ -177,6 +190,7 @@ private:
                                    int goalx_c, int goaly_c, SBPL_2DGRIDSEARCH_TERM_CONDITION termination_condition);
 
     //2D search data
+    int initial_dynamic_bucket_size_;
     CSlidingBucket* OPEN2DBLIST_;
     CIntHeap* OPEN2D_;
     SBPL_2DGridSearchState** searchStates2D_;
@@ -204,6 +218,9 @@ private:
 
     //search iteration
     int iteration_;
+
+    // the size of the block edge in the main gid that corresponds to 1 cell in the 2D grid
+    int downsample_;
 
     //largest optimal g-value computed by search
     int largestcomputedoptf_;

--- a/src/include/sbpl/utils/list.h
+++ b/src/include/sbpl/utils/list.h
@@ -445,20 +445,34 @@ public:
     int currentminelement_priority; //the priority of the current minelement
     int currentfirstbucket_bindex; //index of the bucket that corresponds to the first bucket in the list (lowest priority)
     int currentfirstbucket_priority; //priority of the first bucket in the list
+    int* dynamicsize; //the size of bucket
+    int initialdynamicsize; //initial size of dynamic sized buckets or 0 for fixed size buckets
 
     //constructors
 public:
-    CSlidingBucket(int num_of_buckets, int bucket_size)
+    // an initial_dynamic_size of 0 will use fixed size buckets
+    CSlidingBucket(int num_of_buckets, int bucket_size, int initial_dynamic_size=0)
     {
         numofbuckets = num_of_buckets;
         bucketsize = bucket_size;
+        initialdynamicsize = std::max(0, initial_dynamic_size);
 
         //allocate memory
         bucketV = new AbstractSearchState**[numofbuckets];
         lastelementindexV = new int[numofbuckets];
-        for (int i = 0; i < numofbuckets; i++) {
-            lastelementindexV[i] = -1;
-            bucketV[i] = NULL;
+        if(initialdynamicsize)
+        {
+          dynamicsize = new int[numofbuckets];
+          for (int i = 0; i < numofbuckets; i++) {
+            dynamicsize[i] = 0;
+          }
+        }
+        else
+        {
+          for (int i = 0; i < numofbuckets; i++) {
+              lastelementindexV[i] = -1;
+              bucketV[i] = NULL;
+          }
         }
 
         currentminelement_bindex = currentfirstbucket_bindex = 0;
@@ -470,10 +484,16 @@ public:
     {
         for (int i = 0; i < numofbuckets; i++) {
             if (bucketV[i] != NULL) {
-                delete[] bucketV[i];
+                if(initialdynamicsize)
+                  free(bucketV[i]);
+                else
+                  delete[] bucketV[i];
                 bucketV[i] = NULL;
             }
         }
+        if(initialdynamicsize)
+          delete [] dynamicsize;
+
         delete[] bucketV;
         bucketV = NULL;
         delete[] lastelementindexV;
@@ -499,8 +519,16 @@ public:
         for (int i = 0; i < numofbuckets; i++) {
             lastelementindexV[i] = -1;
             if (bucketV[i] == NULL) continue;
-            for (int eind = 0; eind < bucketsize; eind++)
-                bucketV[i][eind] = NULL;
+            if(initialdynamicsize)
+            {
+              for (int eind = 0; eind < dynamicsize[i]; eind++)
+                  bucketV[i][eind] = NULL;
+            }
+            else
+            {
+              for (int eind = 0; eind < bucketsize; eind++)
+                  bucketV[i][eind] = NULL;
+            }
         }
 
     }
@@ -569,6 +597,26 @@ public:
 
         if (bucketV[bucket_index] == NULL) createbucket(bucket_index);
 
+        if(initialdynamicsize)
+        {
+            // resize the bucket if needed
+            if(lastelementindexV[bucket_index] >= dynamicsize[bucket_index])
+            {
+                const int new_size = std::min(dynamicsize[bucket_index]*2, bucketsize);
+
+                if(new_size != dynamicsize[bucket_index])
+                {
+                    bucketV[bucket_index] = (AbstractSearchState**) realloc(bucketV[bucket_index], sizeof(AbstractSearchState*) * new_size);
+
+                    for(int i=dynamicsize[bucket_index]; i<new_size; i++)
+                    {
+                        bucketV[bucket_index][i] = NULL;
+                    }
+                    dynamicsize[bucket_index] = new_size;
+                }
+            }
+        }
+
         bucketV[bucket_index][lastelementindexV[bucket_index]] = AbstractSearchState1;
 
         //make sure maximum and minimum is correct
@@ -621,9 +669,19 @@ private:
             throw new SBPL_Exception();
         }
 
-        bucketV[bucketindex] = new AbstractSearchState*[bucketsize];
-        for (int eind = 0; eind < bucketsize; eind++)
-            bucketV[bucketindex][eind] = NULL;
+        if(initialdynamicsize)
+        {
+            dynamicsize[bucketindex] = initialdynamicsize;
+            bucketV[bucketindex] = (AbstractSearchState**) malloc(sizeof(AbstractSearchState*) *  dynamicsize[bucketindex] );
+            for (int eind = 0; eind < dynamicsize[bucketindex]; eind++)
+                bucketV[bucketindex][eind] = NULL;
+        }
+        else
+        {
+            bucketV[bucketindex] = new AbstractSearchState*[bucketsize];
+            for (int eind = 0; eind < bucketsize; eind++)
+                bucketV[bucketindex][eind] = NULL;
+        }
     }
 };
 


### PR DESCRIPTION
Can save many GB of memory for large grids.

Added feature: Search the 2D heuristic at a different resolution than the 3D main grid for EnvironmentNAVXYTHETALATTICE. Default is a 1:1 correspondence as before but different resolutions available with Set2DBlockSize.
Added feature: Allow 2D priority queue to have dynamically allocated memory for the CSlidingBucket. Default action is fixed/worst case as before but setting an explicit initial bucket size with Set2DBucketSize will allow the buckets to grow.