### PR TITLE
Fix system pause for windows only

### DIFF
--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -855,7 +855,9 @@ int planandnavigate2d(PlannerType plannerType, char* envCfgFilename)
         }
         printf("\n");
     }
+#ifdef WIN32
     if (bPrint) printf("System Pause (return=%d)\n", system("pause"));
+#endif
 
     //Initialize Environment (should be called before initializing anything else)
     if (!environment_nav2D.InitializeEnv(size_x, size_y, map, startx, starty, goalx, goaly, obsthresh)) {
@@ -1020,7 +1022,9 @@ int planandnavigate2d(PlannerType plannerType, char* envCfgFilename)
             }
             printf("\n");
         }
+#ifdef WIN32
         if (bPrint) printf("System Pause (return=%d)\n", system("pause"));
+#endif
 
         //move along the path
         if (bPlanExists && (int)solution_stateIDs_V.size() > 1) {


### PR DESCRIPTION
The system call pause is only available on windows. If you want to make that line cross-platform you could change from `system("pause")` to `cin.get()`.