### PR TITLE
Fix unused variable warning, when building in release mode

### DIFF
--- a/src/include/sbpl/discrete_space_information/environment.h
+++ b/src/include/sbpl/discrete_space_information/environment.h
@@ -293,7 +293,7 @@ public:
      */
     DiscreteSpaceInformation()
     {
-#ifndef ROS
+#if !defined(ROS) && DEBUG
         const char* envdebug = "envdebug.txt";
 #endif
         if ((fDeb = SBPL_FOPEN(envdebug, "w")) == NULL) {


### PR DESCRIPTION
The `envdebug` variable is actually only used when compiling in DEBUG mode. Otherwise, declaring this gives unused variable warnings.
