### PR TITLE
Init bucketV[i] in CSlidingBucket constructor

### DIFF
--- a/src/include/sbpl/utils/list.h
+++ b/src/include/sbpl/utils/list.h
@@ -461,13 +461,10 @@ public:
             dynamicsize[i] = 0;
           }
         }
-        else
-        {
-          for (int i = 0; i < numofbuckets; i++) {
-              lastelementindexV[i] = -1;
-              bucketV[i] = NULL;
-          }
-        }
+	for (int i = 0; i < numofbuckets; i++) {
+	  lastelementindexV[i] = -1;
+	  bucketV[i] = NULL;
+	}
 
         currentminelement_bindex = currentfirstbucket_bindex = 0;
         currentminelement_index = -1;


### PR DESCRIPTION
**uav_path_planner** crashes (at the following line in method **CSlidingBucket::insert**) when _use_2d_heuristic_ is set to true

`bucketV[bucket_index][lastelementindexV[bucket_index]] = AbstractSearchState1;`

because _bucketV[bucket_index]_ was not set NULL and hence createbucket was never called (also inside method **CSlidingBucket::insert**).
 
`if (bucketV[bucket_index] == NULL) createbucket(bucket_index);`
