### PR TITLE
Fix Visual Studio 2015 warnings

### DIFF
--- a/src/discrete_space_information/environment_nav2D.cpp
+++ b/src/discrete_space_information/environment_nav2D.cpp
@@ -110,7 +110,6 @@ void EnvironmentNAV2D::SetConfiguration(int width, int height, const unsigned ch
     EnvNAV2DCfg.EnvHeight_c = height;
     EnvNAV2DCfg.StartX_c = startx;
     EnvNAV2DCfg.StartY_c = starty;
-    int x;
 
     if (EnvNAV2DCfg.StartX_c < 0 || EnvNAV2DCfg.StartX_c >= EnvNAV2DCfg.EnvWidth_c) {
         throw SBPL_Exception("illegal start coordinates");
@@ -124,7 +123,7 @@ void EnvironmentNAV2D::SetConfiguration(int width, int height, const unsigned ch
 
     //allocate the 2D environment
     EnvNAV2DCfg.Grid2D = new unsigned char*[EnvNAV2DCfg.EnvWidth_c];
-    for (x = 0; x < EnvNAV2DCfg.EnvWidth_c; x++) {
+    for (int x = 0; x < EnvNAV2DCfg.EnvWidth_c; x++) {
         EnvNAV2DCfg.Grid2D[x] = new unsigned char[EnvNAV2DCfg.EnvHeight_c];
     }
 

--- a/src/discrete_space_information/environment_navxythetalat.cpp
+++ b/src/discrete_space_information/environment_navxythetalat.cpp
@@ -429,7 +429,7 @@ void EnvironmentNAVXYTHETALATTICE::ReadConfiguration(FILE* fCfg)
 
     // unallocate the 2d environment
     if (EnvNAVXYTHETALATCfg.Grid2D != NULL) {
-        for (int x = 0; x < EnvNAVXYTHETALATCfg.EnvWidth_c; x++) {
+        for (x = 0; x < EnvNAVXYTHETALATCfg.EnvWidth_c; x++) {
             delete[] EnvNAVXYTHETALATCfg.Grid2D[x];
         }
         delete[] EnvNAVXYTHETALATCfg.Grid2D;
@@ -1700,7 +1700,6 @@ void EnvironmentNAVXYTHETALATTICE::CalculateFootprintForPose(
                     cell.y = discrete_y;
 
                     // insert point if not there already
-                    int pind = 0;
                     for (pind = 0; pind < (int)footprint->size(); pind++) {
                         if (cell.x == footprint->at(pind).x && cell.y == footprint->at(pind).y) break;
                     }
@@ -2468,7 +2467,6 @@ void EnvironmentNAVXYTHETALAT::ConvertStateIDPathintoXYThetaPath(
         }
 
         // now push in the actual path
-        int sourcex_c, sourcey_c, sourcetheta_c;
         GetCoordFromState(sourceID, sourcex_c, sourcey_c, sourcetheta_c);
         double sourcex, sourcey;
         sourcex = DISCXY2CONT(sourcex_c, EnvNAVXYTHETALATCfg.cellsize_m);

--- a/src/planners/ANAplanner.cpp
+++ b/src/planners/ANAplanner.cpp
@@ -860,7 +860,6 @@ vector<int> anaPlanner::GetSearchPath(anaSearchStateSpace_t* pSearchStateSpace, 
 bool anaPlanner::Search(anaSearchStateSpace_t* pSearchStateSpace, vector<int>& pathIds, int & PathCost,
                         bool bFirstSolution, bool bOptimalSolution, double MaxNumofSecs)
 {
-    CKey key;
     TimeStarted = clock();
     searchexpands = 0;
 
@@ -1029,8 +1028,8 @@ int anaPlanner::replan(double allocated_time_secs, vector<int>* solution_stateID
     printf("planner: replan called (bFirstSol=%d, bOptSol=%d)\n", bFirstSolution, bOptimalSolution);
 
     //plan
-    if (!(bFound = Search(pSearchStateSpace_, pathIds, PathCost, bFirstSolution, bOptimalSolution,
-                          allocated_time_secs)))
+    bFound = Search(pSearchStateSpace_, pathIds, PathCost, bFirstSolution, bOptimalSolution, allocated_time_secs);
+    if (!bFound)
     {
         printf("failed to find a solution\n");
     }

--- a/src/planners/adplanner.cpp
+++ b/src/planners/adplanner.cpp
@@ -1332,8 +1332,8 @@ int ADPlanner::replan(double allocated_time_secs, vector<int>* solution_stateIDs
     SBPL_PRINTF("planner: replan called (bFirstSol=%d, bOptSol=%d)\n", bsearchuntilfirstsolution, bOptimalSolution);
 
     //plan for the first solution only
-    if ((bFound = Search(pSearchStateSpace_, pathIds, PathCost, bsearchuntilfirstsolution, bOptimalSolution,
-                         allocated_time_secs)) == false) {
+    bFound = Search(pSearchStateSpace_, pathIds, PathCost, bsearchuntilfirstsolution, bOptimalSolution, allocated_time_secs);
+    if (!bFound) {
         SBPL_PRINTF("failed to find a solution\n");
     }
 
@@ -1468,4 +1468,3 @@ void ADPlanner::get_search_stats(vector<PlannerStats>* s)
         s->push_back(stats[i]);
     }
 }
-

--- a/src/planners/araplanner.cpp
+++ b/src/planners/araplanner.cpp
@@ -1075,8 +1075,8 @@ int ARAPlanner::replan(double allocated_time_secs, vector<int>* solution_stateID
     SBPL_PRINTF("planner: replan called (bFirstSol=%d, bOptSol=%d)\n", bFirstSolution, bOptimalSolution);
 
     //plan
-    if (!(bFound = Search(pSearchStateSpace_, pathIds, PathCost,
-                          bFirstSolution, bOptimalSolution, allocated_time_secs)))
+    bFound = Search(pSearchStateSpace_, pathIds, PathCost, bFirstSolution, bOptimalSolution, allocated_time_secs);
+    if (!bFound)
     {
         SBPL_PRINTF("failed to find a solution\n");
     }
@@ -1213,7 +1213,7 @@ double ARAPlanner::compute_suboptimality()
             ARAState* state = (ARAState*)currElem;
             assert(state);
 
-            int stateID = state->MDPstate->StateID;
+            // int stateID = state->MDPstate->StateID;
 
             // update the min to the f-value of this state if necessary
             int h = state->h;

--- a/src/planners/mhaplanner.cpp
+++ b/src/planners/mhaplanner.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2015, Maxim Likhachev
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Carnegie Mellon University nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -197,11 +197,11 @@ int MHAPlanner::replan(
     end_time = GetTime();
     m_elapsed += (end_time - start_time);
 
-    while (!m_open[0].emptyheap() && !time_limit_reached()) { 
+    while (!m_open[0].emptyheap() && !time_limit_reached()) {
         start_time = GetTime();
 
         // special case for mha* without additional heuristics
-        if (num_heuristics() == 1) { 
+        if (num_heuristics() == 1) {
             if (m_goal_state->g <= get_minf(m_open[0])) {
                 m_eps_satisfied = m_eps * m_eps_mha;
                 extract_path(solution_stateIDs_V, solcost);
@@ -458,7 +458,6 @@ void MHAPlanner::clear()
     // free states
     for (size_t i = 0; i < m_search_states.size(); ++i) {
         // unmap graph to search state
-        MHASearchState* search_state = m_search_states[i];
         const int state_id = m_search_states[i]->state_id;
         int* idxs = environment_->StateID2IndexMapping[state_id];
         idxs[MHAMDP_STATEID2IND] = -1;
@@ -541,9 +540,9 @@ void MHAPlanner::expand(MHASearchState* state, int hidx)
     ++m_num_expansions;
 
     // remove s from all open lists
-    for (int hidx = 0; hidx < num_heuristics(); ++hidx) {
-        if (m_open[hidx].inheap(&state->od[hidx].open_state)) {
-            m_open[hidx].deleteheap(&state->od[hidx].open_state);
+    for (int temp_hidx = 0; temp_hidx < num_heuristics(); ++temp_hidx) {
+        if (m_open[temp_hidx].inheap(&state->od[temp_hidx].open_state)) {
+            m_open[temp_hidx].deleteheap(&state->od[temp_hidx].open_state);
         }
     }
 
@@ -569,14 +568,14 @@ void MHAPlanner::expand(MHASearchState* state, int hidx)
                 SBPL_DEBUG("  Update in search %d with f = %d", 0, fanchor);
 
                 if (!closed_in_add_search(succ_state)) {
-                    for (int hidx = 1; hidx < num_heuristics(); ++hidx) {
-                        int fn = compute_key(succ_state, hidx);
+                    for (int temp_hidx = 1; temp_hidx < num_heuristics(); ++temp_hidx) {
+                        int fn = compute_key(succ_state, temp_hidx);
                         if (fn <= m_eps_mha * fanchor) {
-                            insert_or_update(succ_state, hidx, fn);
-                            SBPL_DEBUG("  Update in search %d with f = %d", hidx, fn);
+                            insert_or_update(succ_state, temp_hidx, fn);
+                            SBPL_DEBUG("  Update in search %d with f = %d", temp_hidx, fn);
                         }
                         else {
-                            SBPL_DEBUG("  Skipping update of in search %d (%0.3f > %0.3f)", hidx, (double)fn, m_eps_mha * fanchor);
+                            SBPL_DEBUG("  Skipping update of in search %d (%0.3f > %0.3f)", temp_hidx, (double)fn, m_eps_mha * fanchor);
                         }
                     }
                 }

--- a/src/planners/rstarplanner.cpp
+++ b/src/planners/rstarplanner.cpp
@@ -1371,7 +1371,8 @@ int RSTARPlanner::replan(double allocated_time_secs, vector<int>* solution_state
     SBPL_PRINTF("planner: replan called (bFirstSol=%d, bOptSol=%d)\n", bFirstSolution, bOptimalSolution);
 
     //plan
-    if ((bFound = Search(pathIds, PathCost, bFirstSolution, bOptimalSolution, allocated_time_secs)) == false) {
+    bFound = Search(pathIds, PathCost, bFirstSolution, bOptimalSolution, allocated_time_secs);
+    if (!bFound) {
         SBPL_PRINTF("failed to find a solution\n");
     }
 
@@ -1460,4 +1461,3 @@ void RSTARPlanner::print_searchpath(FILE* fOut)
 }
 
 //---------------------------------------------------------------------------------------------------------
-


### PR DESCRIPTION
Fix some Visual Studio 2015 warnings:

1. warning C4189: initialized but not referenced
2. warning C4456: declaration hides previous local declaration
3. warning C4706: assignment within conditional expression

In addition, some trailing whitespaces have been removed.
