### PR TITLE
add cancel() to the SBPLPlanner interface

### DIFF
--- a/src/include/sbpl/planners/planner.h
+++ b/src/include/sbpl/planners/planner.h
@@ -167,7 +167,6 @@ public:
      */
     AbstractSearchStateType_t StateType;
 
-public:
     AbstractSearchState()
     {
         StateType = ABSTRACT_GENERALSTATE;
@@ -341,10 +340,26 @@ public:
      */
     virtual void set_initialsolution_eps(double initialsolution_eps) { }
 
+    /**
+     * \brief sends a cancelling request.
+     * \returns true, if the canceling request was successfull.
+     */
+    virtual bool cancel()
+    {
+        canceled_ = true;
+        return true;
+    }
+
+    SBPLPlanner()
+    {
+        canceled_ = false;
+    }
+
     virtual ~SBPLPlanner() { }
 
 protected:
     DiscreteSpaceInformation *environment_;
+    bool canceled_;
 };
 
 #endif

--- a/src/planners/ANAplanner.cpp
+++ b/src/planners/ANAplanner.cpp
@@ -892,6 +892,11 @@ bool anaPlanner::Search(anaSearchStateSpace_t* pSearchStateSpace, vector<int>& p
            (clock() - TimeStarted) < MaxNumofSecs * (double)CLOCKS_PER_SEC)
     {
         loop_time = clock();
+
+        if (canceled_) {
+            return false;
+        }
+
         //decrease eps for all subsequent iterations
         /*if(fabs(pSearchStateSpace->eps_satisfied - pSearchStateSpace->eps) < ERR_EPS && !bFirstSolution)
          {
@@ -1024,6 +1029,8 @@ int anaPlanner::replan(double allocated_time_secs, vector<int>* solution_stateID
     bool bFirstSolution = this->bsearchuntilfirstsolution;
     bool bOptimalSolution = false;
     *psolcost = 0;
+
+    canceled_ = false;
 
     printf("planner: replan called (bFirstSol=%d, bOptSol=%d)\n", bFirstSolution, bOptimalSolution);
 

--- a/src/planners/adplanner.cpp
+++ b/src/planners/adplanner.cpp
@@ -1133,6 +1133,11 @@ bool ADPlanner::Search(ADSearchStateSpace_t* pSearchStateSpace, vector<int>& pat
                (clock() - TimeStarted) < repair_time * (double)CLOCKS_PER_SEC))
     {
         loop_time = clock();
+
+        if (canceled_){
+            return false;
+        }
+
         //it will be a new search iteration
         if (pSearchStateSpace->searchiteration == 0) pSearchStateSpace->searchiteration++;
 
@@ -1328,6 +1333,8 @@ int ADPlanner::replan(double allocated_time_secs, vector<int>* solution_stateIDs
     bool bFound = false;
     *psolcost = 0;
     bool bOptimalSolution = false;
+
+    canceled_ = false;
 
     SBPL_PRINTF("planner: replan called (bFirstSol=%d, bOptSol=%d)\n", bsearchuntilfirstsolution, bOptimalSolution);
 

--- a/src/planners/araplanner.cpp
+++ b/src/planners/araplanner.cpp
@@ -938,6 +938,12 @@ bool ARAPlanner::Search(ARASearchStateSpace_t* pSearchStateSpace, vector<int>& p
                (clock() - TimeStarted) < repair_time * (double)CLOCKS_PER_SEC))
     {
         loop_time = clock();
+
+        if (canceled_)
+        {
+            return false;
+        }
+
         //decrease eps for all subsequent iterations
         if (fabs(pSearchStateSpace->eps_satisfied - pSearchStateSpace->eps) < ERR_EPS && !bFirstSolution) {
             pSearchStateSpace->eps = pSearchStateSpace->eps - dec_eps;
@@ -1071,6 +1077,8 @@ int ARAPlanner::replan(double allocated_time_secs, vector<int>* solution_stateID
     bool bFirstSolution = this->bsearchuntilfirstsolution;
     bool bOptimalSolution = false;
     *psolcost = 0;
+
+    canceled_ = false;
 
     SBPL_PRINTF("planner: replan called (bFirstSol=%d, bOptSol=%d)\n", bFirstSolution, bOptimalSolution);
 

--- a/src/planners/lazyARA.cpp
+++ b/src/planners/lazyARA.cpp
@@ -472,6 +472,10 @@ bool LazyARAPlanner::Search(vector<int>& pathIds, int& PathCost)
     // the main loop of ARA*
     while (eps_satisfied > params.final_eps && !outOfTime()) {
 
+        if (canceled_) {
+            return false;
+        }
+
         // run weighted A*
         clock_t before_time = clock();
         int before_expands = search_expands;
@@ -607,6 +611,8 @@ int LazyARAPlanner::replan(
     SBPL_DEBUG("planner: replan called");
     params = p;
     use_repair_time = params.repair_time >= 0;
+
+    canceled_ = false;
 
     if (goal_state_id < 0) {
         SBPL_ERROR("ERROR searching: no goal state set");

--- a/src/planners/mhaplanner.cpp
+++ b/src/planners/mhaplanner.cpp
@@ -151,6 +151,7 @@ int MHAPlanner::replan(
     }
 
     m_params = params;
+    canceled_ = false;
 
     SBPL_INFO("Generic Search parameters:");
     SBPL_INFO("  Initial Epsilon: %0.3f", m_params.initial_eps);
@@ -199,6 +200,10 @@ int MHAPlanner::replan(
 
     while (!m_open[0].emptyheap() && !time_limit_reached()) {
         start_time = GetTime();
+
+        if (canceled_) {
+            return 0;
+        }
 
         // special case for mha* without additional heuristics
         if (num_heuristics() == 1) {

--- a/src/planners/rstarplanner.cpp
+++ b/src/planners/rstarplanner.cpp
@@ -1251,6 +1251,11 @@ bool RSTARPlanner::Search(vector<int>& pathIds, int & PathCost, bool bFirstSolut
     {
         loop_time = clock();
 
+        if (canceled_)
+        {
+            return false;
+        }
+
         //decrease eps for all subsequent iterations
         if (fabs(pSearchStateSpace->eps_satisfied - pSearchStateSpace->eps) < ERR_EPS && !bFirstSolution) {
             pSearchStateSpace->eps = pSearchStateSpace->eps - dec_eps;
@@ -1367,6 +1372,7 @@ int RSTARPlanner::replan(double allocated_time_secs, vector<int>* solution_state
     bool bFirstSolution = this->bsearchuntilfirstsolution;
     bool bOptimalSolution = false;
     *psolcost = 0;
+    canceled_ = false;
 
     SBPL_PRINTF("planner: replan called (bFirstSol=%d, bOptSol=%d)\n", bFirstSolution, bOptimalSolution);
 

--- a/src/planners/viplanner.cpp
+++ b/src/planners/viplanner.cpp
@@ -374,6 +374,8 @@ int VIPlanner::replan(double allocatedtime, vector<int>* solution_stateIDs_V)
     FILE* fPolicy = SBPL_FOPEN(policy, "w");
     FILE* fStat = SBPL_FOPEN(stat, "w");
 
+    canceled_ = false;
+
     //initialization
     InitializePlanner();
 
@@ -382,6 +384,10 @@ int VIPlanner::replan(double allocatedtime, vector<int>* solution_stateIDs_V)
 
     //--------------iterate-------------------------------
     while (((clock() - starttime) / (double)CLOCKS_PER_SEC) < allocatedtime && g_belldelta > MDP_ERRDELTA) {
+
+        if (canceled_) {
+            return 0;
+        }
         viPlanner.iteration++;
 
         g_belldelta = 0;


### PR DESCRIPTION
Hi, I added a `cancel()` method to all planners. This is required for the sbpl_lattice_planner. See [the PR there](https://github.com/tu-darmstadt-ros-pkg/sbpl_lattice_planner/pull/2).
Thanks!