### PR TITLE
fix: Ensure chars are signed on all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ set(SBPL_VERSION ${SBPL_MAJOR_VERSION}.${SBPL_MINOR_VERSION}.${SBPL_PATCH_VERSIO
 
 set(CMAKE_BUILD_TYPE Release)
 
+# The default signedness of `char` is not defined in the C++ standard.  The
+# SBPL code is assuming that `char` is signed but on ARM platforms it is
+# unsigned, and thus SBPL is not working there.  The following flag sets the
+# default signedness to "signed" independent of the platform.
+add_definitions(-fsigned-char)
+
 include_directories(src/include)
 
 add_library(sbpl SHARED


### PR DESCRIPTION
The default signedness of `char` is not defined in the C++ standard.
The SBPL code seems to assume that `char` is signed but on ARM platforms
it is unsigned, and thus SBPL fails in some situations there.

The `-fsigned-char` flag in the CMakeLists.txt sets the default
signedness to "signed" independent of the platform, thus making it work
on ARM.